### PR TITLE
Investigate news edit feature failure

### DIFF
--- a/src/app/admin/news/page.tsx
+++ b/src/app/admin/news/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 interface NewsItem {
-  _id: string;
+  id: string;
   title: string;
   summary: string;
   date: string;
@@ -55,7 +55,7 @@ export default function AdminNews() {
         });
         
         if (response.ok) {
-          setNews(prev => prev.filter(item => item._id !== newsId));
+          setNews(prev => prev.filter(item => item.id !== newsId));
           alert('Xóa tin tức thành công!');
         } else {
           alert('Có lỗi xảy ra khi xóa tin tức');
@@ -76,7 +76,7 @@ export default function AdminNews() {
     try {
       // Cập nhật state ngay lập tức để UI responsive
       setNews(prev => prev.map(item => 
-        item._id === updatedNews._id ? updatedNews : item
+        item.id === updatedNews.id ? updatedNews : item
       ));
       setShowEditModal(false);
       setEditingNews(null);
@@ -121,7 +121,7 @@ export default function AdminNews() {
         {/* News Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {news.map((item) => (
-            <div key={item._id} className="bg-white rounded-lg shadow-md overflow-hidden">
+            <div key={item.id} className="bg-white rounded-lg shadow-md overflow-hidden">
               {item.image && (
                 <div className="relative h-48 w-full">
                   <Image
@@ -160,7 +160,7 @@ export default function AdminNews() {
                     Sửa
                   </button>
                   <button
-                    onClick={() => handleDelete(item._id)}
+                    onClick={() => handleDelete(item.id)}
                     className="flex-1 bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-md text-sm"
                   >
                     Xóa
@@ -226,7 +226,7 @@ function EditNewsModal({
         formDataToSend.append('link', formData.link);
         formDataToSend.append('image', imageFile);
         
-        const response = await fetch(`/api/news/${news._id}`, {
+        const response = await fetch(`/api/news/${news.id}`, {
           method: 'PUT',
           body: formDataToSend,
         });
@@ -239,7 +239,7 @@ function EditNewsModal({
         }
       } else {
         // Nếu không có ảnh mới, chỉ cập nhật text
-        const response = await fetch(`/api/news/${news._id}`, {
+        const response = await fetch(`/api/news/${news.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(formData)

--- a/src/app/api/news/[id]/route.ts
+++ b/src/app/api/news/[id]/route.ts
@@ -1,7 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { connectDB } from '@/src/lib/mongodb';
-import { News } from '@/src/models/News';
+import { prisma } from '@/src/lib/prisma';
+import { v2 as cloudinary } from 'cloudinary';
+import { Readable } from 'stream';
 
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+function uploadToCloudinary(fileBuffer: Buffer, folder: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const uploadStream = cloudinary.uploader.upload_stream(
+      { folder, resource_type: 'image' },
+      (error, result) => {
+        if (error) return reject(error);
+        resolve(result.secure_url);
+      }
+    );
+    Readable.from(fileBuffer).pipe(uploadStream);
+  });
+}
 
 // PUT: Cập nhật tin tức
 export async function PUT(
@@ -9,91 +28,32 @@ export async function PUT(
   { params }: { params: { id: string } }
 ) {
   try {
-    console.log('=== UPDATE NEWS API CALLED ===');
-    console.log('Content-Type:', request.headers.get('content-type'));
-    console.log('News ID:', params.id);
-    
     const contentType = request.headers.get('content-type') || '';
-    let title, summary, date, link, imageUrl;
+
+    let title = '';
+    let summary = '';
+    let date = '';
+    let link = '';
+    let imageUrl: string | undefined = undefined;
 
     if (contentType.includes('multipart/form-data')) {
-      console.log('Processing FormData (with image)');
-      // Xử lý FormData (có ảnh)
       const formData = await request.formData();
       title = formData.get('title')?.toString() || '';
       summary = formData.get('summary')?.toString() || '';
       date = formData.get('date')?.toString() || '';
       link = formData.get('link')?.toString() || '';
-      
-      console.log('Form data received:', { title, summary, date, link });
-      
-      const imageFile = formData.get('image') as File | null;
-      console.log('Image file received:', imageFile ? {
-        name: imageFile.name,
-        size: imageFile.size,
-        type: imageFile.type
-      } : 'No image');
-      
-      if (imageFile) {
-        try {
-          console.log('Starting Cloudinary upload...');
-          console.log('Cloudinary config:', {
-            cloud_name: process.env.CLOUDINARY_CLOUD_NAME ? 'SET' : 'NOT SET',
-            api_key: process.env.CLOUDINARY_API_KEY ? 'SET' : 'NOT SET',
-            api_secret: process.env.CLOUDINARY_API_SECRET ? 'SET' : 'NOT SET'
-          });
-          
-          // Upload lên Cloudinary
-          const { v2: cloudinary } = await import('cloudinary');
-          cloudinary.config({
-            cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
-            api_key: process.env.CLOUDINARY_API_KEY,
-            api_secret: process.env.CLOUDINARY_API_SECRET,
-          });
 
-          const buffer = Buffer.from(await imageFile.arrayBuffer());
-          const base64Image = buffer.toString('base64');
-          const dataURI = `data:${imageFile.type};base64,${base64Image}`;
-          
-          console.log('Uploading to Cloudinary...');
-          const result = await cloudinary.uploader.upload(dataURI, {
-            folder: 'news',
-            public_id: `news_${Date.now()}`,
-            overwrite: true,
-          });
-          
-          imageUrl = result.secure_url;
-          console.log('✅ Image uploaded to Cloudinary successfully:', imageUrl);
-        } catch (err) {
-          console.error('❌ Error uploading to Cloudinary:', err);
-          console.log('Falling back to local storage...');
-          
-          // Fallback: thử lưu local nếu có thể
-          try {
-            const fs = await import('fs/promises');
-            const path = await import('path');
-            const buffer = Buffer.from(await imageFile.arrayBuffer());
-            const filename = `${Date.now()}_${imageFile.name}`;
-            const uploadDir = path.join(process.cwd(), 'public', 'uploads');
-            await fs.mkdir(uploadDir, { recursive: true });
-            await fs.writeFile(path.join(uploadDir, filename), buffer);
-            imageUrl = `/uploads/${filename}`;
-            console.log('✅ Image saved locally:', imageUrl);
-          } catch (localErr) {
-            console.warn('❌ Failed to save image locally:', localErr);
-            imageUrl = '';
-          }
-        }
+      const imageFile = formData.get('image') as File | null;
+      if (imageFile) {
+        const buffer = Buffer.from(await imageFile.arrayBuffer());
+        imageUrl = await uploadToCloudinary(buffer, 'news');
       }
     } else {
-      console.log('Processing JSON (text only)');
-      // Xử lý JSON (chỉ text)
       const body = await request.json();
       title = body.title;
       summary = body.summary;
       date = body.date;
       link = body.link;
-      console.log('JSON data received:', { title, summary, date, link });
     }
 
     if (!title || !summary || !date) {
@@ -103,44 +63,18 @@ export async function PUT(
       );
     }
 
-    await connectDB();
-    
-    console.log('Final update data:', { title, summary, date, link, imageUrl });
-    
     const updateData: any = { title, summary, date, link };
-    if (imageUrl) {
-      updateData.image = imageUrl;
-      console.log('✅ Will update with new image:', imageUrl);
-    } else {
-      console.log('ℹ️ No image update (keeping existing image)');
-    }
-    
-    console.log('Updating database with:', updateData);
-    const updatedNews = await News.findByIdAndUpdate(
-      params.id,
-      updateData,
-      { new: true, runValidators: true }
-    );
+    if (imageUrl) updateData.image = imageUrl;
 
-    if (!updatedNews) {
-      return NextResponse.json(
-        { error: 'Không tìm thấy tin tức' },
-        { status: 404 }
-      );
-    }
-
-    return NextResponse.json({ 
-      success: true, 
-      news: updatedNews,
-      message: 'Cập nhật tin tức thành công'
+    const updated = await prisma.news.update({
+      where: { id: params.id },
+      data: updateData,
     });
 
+    return NextResponse.json({ success: true, news: updated, message: 'Cập nhật tin tức thành công' });
   } catch (error) {
     console.error('Error updating news:', error);
-    return NextResponse.json(
-      { error: 'Server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
   }
 }
 
@@ -150,24 +84,13 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    await connectDB();
-    
-    const news = await News.findById(params.id);
-    
+    const news = await prisma.news.findUnique({ where: { id: params.id } });
     if (!news) {
-      return NextResponse.json(
-        { error: 'Không tìm thấy tin tức' },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Không tìm thấy tin tức' }, { status: 404 });
     }
-
     return NextResponse.json({ success: true, news });
-
   } catch (error) {
     console.error('Error fetching news:', error);
-    return NextResponse.json(
-      { error: 'Server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
   }
 }

--- a/src/components/NewsSection.tsx
+++ b/src/components/NewsSection.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 interface NewsItem {
-  _id: string;
+  id: string;
   title: string;
   summary?: string;
   image: string;
@@ -47,10 +47,10 @@ export default function NewsSection() {
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
         {news.slice(0, 5).map((item) => (
           <div
-            key={item._id}
+            key={item.id}
             className="bg-white rounded-xl shadow hover:shadow-md transition-all duration-200"
           >
-            <Link href={`/news/${item._id}`} className="block">
+            <Link href={`/news/${item.id}`} className="block">
               <div className="relative w-full h-40 rounded-t-xl overflow-hidden">
                 <Image
                   src={item.image}


### PR DESCRIPTION
Fixes admin news edit by unifying `id` usage and refactoring the update API to use Prisma with Cloudinary.

The admin news page used `_id` while the API returned `id`, causing update requests to fail with `undefined` IDs. This PR synchronizes ID usage and refactors the update API for consistency with other Prisma-based news operations, including Cloudinary image handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3289ee9-981b-4993-9273-f9d8c01ecdab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3289ee9-981b-4993-9273-f9d8c01ecdab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

